### PR TITLE
Fixes a broken regex

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,2 @@
 .travis.yml
-+^CONDUCT.md$
+^CONDUCT\.md$


### PR DESCRIPTION
Fixes a typo in .Rbuildignore that is preventing the package from building on ropensci drat.